### PR TITLE
Option to output array

### DIFF
--- a/src/Glyphy.jl
+++ b/src/Glyphy.jl
@@ -84,7 +84,7 @@ function glyphy(s::String; output=:stdout, showall=(output==:stdout ? false : tr
     end
     q = _query_db(findstatement)
     if output == :array
-        retval = similar([], length(q), 5)
+        retval = similar([], showall ? length(q) : min(length(q), 50), 5)
         r = 1
         for row in q
             retval[r, 1] = lpad(string(row.id, base=16), 5, "0")
@@ -92,6 +92,7 @@ function glyphy(s::String; output=:stdout, showall=(output==:stdout ? false : tr
             retval[r, 3] = row.juliamono |> Bool
             retval[r, 4] = row.name
             retval[r, 5] = row.shortcut
+            r >= size(retval, 1) && break
             r += 1
         end
         return retval


### PR DESCRIPTION
I feel that it would be really nice to be able get the output of `glyphy` as value that can be used by other Julia code. This would make it much easier for other packages to use Glyphy and it gives the user much more flexibility to do custom formatting of the output, to search in it etc. Personally, I like to read large output with the TerminalPager package and this PR would allow me to do this easily.

I am of course open to suggestions for improvement and if you want to get this into the master branch then I will gladly write some tests and make the necessary documentation updates.