### PR TITLE
Array output continued

### DIFF
--- a/src/Glyphy.jl
+++ b/src/Glyphy.jl
@@ -48,8 +48,24 @@ function _printentry(q)
     println()
 end
 
+function _make_array(q, showall::Bool=true)
+    retval = similar([], showall ? length(q) : min(length(q), 50), 5)
+    r = 1
+    for row in q
+        retval[r, 1] = lpad(string(row.id, base=16), 5, "0")
+        retval[r, 2] = Char(row.id)
+        retval[r, 3] = row.juliamono |> Bool
+        retval[r, 4] = row.name
+        retval[r, 5] = row.shortcut
+        r >= size(retval, 1) && break
+        r += 1
+    end
+    return retval
+end
+
 """
     glyphy(s::String; showall=false, shortcut=true)
+    glyphy(s::String; output, showall=true, shortcut=true)
 
 Find glyphs with `string` in the name.
 
@@ -72,6 +88,9 @@ The "✓" indicates that the glyph is available in the JuliaMono font.
 If there's a keyboard shortcut in the Julia REPL,
 it's shown after the `⌨`.
 
+Setting `output=:array` will cause `glyphy` to return an `Array` with the
+information instead of writing it to `stdout`.
+
 The characters with "<control>" in the name aren't included.
 The `shortcut` keyword is ignored.
 """
@@ -84,20 +103,7 @@ function glyphy(s::String; output=:stdout, showall=(output==:stdout ? false : tr
         findstatement = "select * from unicodechart where regexp('$s', name);"
     end
     q = _query_db(findstatement)
-    if output == :array
-        retval = similar([], showall ? length(q) : min(length(q), 50), 5)
-        r = 1
-        for row in q
-            retval[r, 1] = lpad(string(row.id, base=16), 5, "0")
-            retval[r, 2] = Char(row.id)
-            retval[r, 3] = row.juliamono |> Bool
-            retval[r, 4] = row.name
-            retval[r, 5] = row.shortcut
-            r >= size(retval, 1) && break
-            r += 1
-        end
-        return retval
-    end
+    output == :array && return _make_array(q, showall)
     if length(q) == 0
         println("0 results")
         return
@@ -124,7 +130,7 @@ function glyphy(s::String; output=:stdout, showall=(output==:stdout ? false : tr
 end
 
 """
-    glyphy(r::UnitRange)
+    glyphy(r::UnitRange; output=:stdout)
 
 Find the glyph numbers in the range `r` in the Unicode chart.
 
@@ -144,11 +150,15 @@ glyphy(0x0:0x7F)
 0007e   ~   ✓    tilde
 ```
 
+Setting `output=:array` will cause `glyphy` to return an `Array` with the
+information instead of writing it to `stdout`.
+
 Empty glyphs are usually omitted, so 0x7F ("DELETE") isn't listed.
 """
-function glyphy(r::UnitRange)
+function glyphy(r::UnitRange; output=:stdout)
     findstatement = "select * from unicodechart where id >= '$(r.start)' and id <= '$(r.stop)';"
     q = Glyphy._query_db(findstatement)
+    output == :array && return _make_array(q)
     if length(q) == 0
         println(" can't find anything in the range 0x$(lpad(string(r.start, base=16), 5, string(0))) to 0x$(lpad(string(r.stop, base=16), 5, string(0)))")
         return nothing
@@ -161,7 +171,7 @@ function glyphy(r::UnitRange)
 end
 
 """
-    glyphy(a::Array)
+    glyphy(a::Array; output=:stdout)
 
 Find the glyph numbers in the array `a` in the Unicode chart.
 
@@ -174,8 +184,11 @@ glyphy([0x2311, 0x3124, 0x6742, 0xa100])
 03124   ㄤ       bopomofo letter ang
 0a100   ꄀ       yi syllable dit
 ```
+
+Setting `output=:array` will cause `glyphy` to return an `Array` with the
+information instead of writing it to `stdout`.
 """
-function glyphy(a::Array{T, 1} where {T<:Integer})
+function glyphy(a::Array{T, 1} where {T<:Integer}; output=:stdout)
     s = IOBuffer()
     for (i, n) in enumerate(a)
         write(s, "'")
@@ -186,6 +199,7 @@ function glyphy(a::Array{T, 1} where {T<:Integer})
     values = String(take!(s))    
     findstatement = "select * from unicodechart where id in ( $(values) );"
     q = Glyphy._query_db(findstatement)
+    output == :array && return _make_array(q)
     if length(q) == 0
         println(" can't find anything for any of these glyph numbers")
         return nothing
@@ -199,7 +213,7 @@ end
 
 
 """
-   glyphy(unicodepoint::T where {T<:Integer})
+   glyphy(unicodepoint::T where {T<:Integer}; output=:stdout)
 
 Find glyph number `int` in the Unicode chart.
 
@@ -226,10 +240,14 @@ glyphy(123)
 
 0007b   {   ✓    left curly bracket
 ```
+
+Setting `output=:array` will cause `glyphy` to return an `Array` with the
+information instead of writing it to `stdout`.
 """
-function glyphy(unicodepoint::T where {T<:Integer})
+function glyphy(unicodepoint::T where {T<:Integer}; output=:stdout)
     findstatement = "select * from unicodechart where id = '$unicodepoint';"
     q = _query_db(findstatement)
+    output == :array && return _make_array(q)
     if length(q) == 0
         println(" can't find anything at 0x$(string(unicodepoint, base=16))")
         return nothing

--- a/src/Glyphy.jl
+++ b/src/Glyphy.jl
@@ -69,10 +69,11 @@ option to see them all.
 The "✓" indicates that the glyph is available in the JuliaMono font.
 "pua" = Private Use Area.
 
-If `shortcut=true`, if there's a keyboard shortcut in the Julia REPL, 
+If there's a keyboard shortcut in the Julia REPL,
 it's shown after the `⌨`.
 
 The characters with "<control>" in the name aren't included.
+The `shortcut` keyword is ignored.
 """
 function glyphy(s::String; output=:stdout, showall=(output==:stdout ? false : true), shortcut=true)
     if all(c -> isletter(c) || isdigit(c) || isspace(c) || isequal(c, '-') || isequal(c, '<'), map(Char, s)) == true

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,4 +9,11 @@ using Test
     glyphy(0xffee:0xffff)
     glyphy([43])
     glyphy([43, 123, 2341, 12])
+
+    @testset "array output" begin
+        @test all(size(glyphy("and"; output=:array)) .>= (200, 5))
+        @test glyphy("peacock"; output=:array) == ["1f99a" '🦚' false "peacock" ":peacock:"]
+        @test glyphy(0x20ac; output=:array) == ["020ac" '€' true "euro sign" "euro"]
+        @test glyphy(0x3a:0x3b; output=:array) == ["0003a" ':' true "colon" ""; "0003b" ';' true "semicolon" ""]
+    end
 end


### PR DESCRIPTION
Nice that you accepted my previous PR. After submitting it I realised that the `glyphy` function has more methods where the `output` keyword also makes sense, so I added it to them also. This PR also includes all docstring updates as well as tests for all `output=:array` cases. Also, in the first commit I changed the docstring description of the `shortcut` keyword to match the actual code.

I am a bit in doubt about whether `output` should be a keyword or a positional argument. A positional argument would certainly mean less typing which would be handy for me, but we should of course choose whichever is best for all users. Please let me know if you also prefer `output` to be a positional argument, then I will submit a commit making that change.